### PR TITLE
ci(deploy): 接入 D3 复用流水线 (ci-templates @v1)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,24 @@
+# 调 Lane B 复用流水线(ci-templates @v1)。push main 自动 build→ACR→入 tailnet→SSH n305→探针→部署。
+# 钉 @v1(不钉 @main)——一个坏 commit 不会扇出炸全舰队。
+name: deploy
+on:
+  push:
+    branches: [main]            # 本仓默认分支是 main
+
+jobs:
+  ship:
+    uses: zj1123581321/ci-templates/.github/workflows/build-deploy.yml@v1
+    with:
+      image_name: youtube-download-api                  # == ACR 镜像名 == 宿主 compose 的 image(crpi-.../zlx-personal/youtube-download-api)
+      host: 100.68.21.80                                 # n305 的 Tailscale IP(runner 入 tailnet 后可达)
+      ssh_user: zlx
+      deploy_dir: /opt/media/youtube_download_api
+      healthcheck_url: http://localhost:8300/health      # 宿主发布端口是 8300(容器内 8000)
+      ci_templates_ref: v1
+    secrets:                                             # 逐个显式传,最小权限
+      ACR_USERNAME: ${{ secrets.ACR_USERNAME }}
+      ACR_PASSWORD: ${{ secrets.ACR_PASSWORD }}
+      SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+      KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
+      TS_AUTHKEY: ${{ secrets.TS_AUTHKEY }}
+      CI_TEMPLATES_PAT: ${{ secrets.CI_TEMPLATES_PAT }}


### PR DESCRIPTION
## D3 接入: youtube-download-api (n305 容器 youtube-api)

新增 caller `.github/workflows/deploy.yml`,复用 ci-templates `build-deploy.yml@v1`。push main 触发 build→ACR→入 tailnet→SSH n305→`/health` 探针→部署。

### SSH 只读核实 (n305, 唯一真相源)
| 项 | hint | 核实值 |
|---|---|---|
| 宿主端口→容器 | 8300 | `8300→8000` (docker ps 实测) |
| 部署目录 | /opt/media/youtube_download_api | 一致 ✓ |
| health 路径 | ? | `/health` (curl 200) |
| 默认分支 | ? | `main` |
| 宿主 compose | ? | `image: crpi-.../zlx-personal/youtube-download-api:latest` (image 形态, ACR-able) ✓ |
| image_name | - | `youtube-download-api` (== ACR namespace 后段) |

### 门禁 (spec §4)
- 门0 宿主 compose 兼容: PASS (image:latest,非 build:)
- 门1 SSH 只读核实: PASS (端口/目录/health 200/默认分支)
- 门2 caller deploy.yml: PASS (yaml.safe_load 合法, 6 secret 显式, @v1)
- 门3 6 secret: PASS (set-fleet-secrets.sh 已配齐)
- 门4 瘦身: not-applicable — 镜像 1.32GB(>1GB)但 Dockerfile **已多阶段 + python:3.11-slim + 已清缓存/tests/docs/node_modules**。剩余体积来自 ffmpeg + Deno + Node.js + yt-dlp Python 依赖,均为运行时必需;进一步缩减须删运行时组件,违反 §3"禁改运行时行为"。**不动 Dockerfile**。
- 门5 一分支一 PR: 本 PR (feat/onboard-d3 → main),**未触发部署**

### 早晨部署提醒
首次接入无 last_good_tag,探针失败不自动回滚,需人盯。合并/push main 即触发部署。

🤖 Generated with [Claude Code](https://claude.com/claude-code)