### PR TITLE
Onboard to gate-hub CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "python-uv",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "features": { "ghcr.io/va-h/devcontainers-features/uv@sha256:a15737142539d150ef4d358e2d6a7424a0a2f3dc43b29a3aa1b50162a8b11bc1": {} },
+  "postCreateCommand": "uv sync"
+}

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -1,0 +1,22 @@
+# Dropped into each repo as .github/workflows/ci.yml by scripts/onboard-repo.sh.
+# The only per-repo file — everything else lives in gate-hub.
+name: CI
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# The reusable gate requests `pull-requests: write` (for the Codex review comment).
+# The caller MUST grant it here — otherwise the run fails at startup with a
+# generic "workflow file issue" (reusable-workflow permission escalation).
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    uses: zlxlabs/gate-hub/.github/workflows/gate.yml@main
+    with:
+      tier: personal        # personal | internal | saas
+      runner: self          # self (self-hosted) | hosted (GitHub free minutes — cold repos / pilot)
+      has_ui: false
+      design_doc: ""        # e.g. docs/DESIGN.md


### PR DESCRIPTION
Adds the self-hosted CI gate (tier: `personal`) and a `python-uv` devcontainer.
Managed centrally in `zlxlabs/gate-hub`.