### PR TITLE
chore(ci): allow read-only review ledger access

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -12,6 +12,7 @@ on:
 # The caller MUST grant it here — otherwise the run fails at startup with a
 # generic "workflow file issue" (reusable-workflow permission escalation).
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 


### PR DESCRIPTION
The shared Gate now builds a cumulative Codex review effectiveness ledger.

This grants the reusable workflow the minimal `actions: read` scope required to load prior ledger artifacts. It does not grant write access to Actions, contents, or deployments.

The PR itself validates the new PR-size preflight, Codex review, and ledger upload path.