### PR TITLE
ci: gate caller 迁到 Required Gate v2（影子移出关键路径）

### DIFF
--- a/.github/workflows/gate-shadow.yml
+++ b/.github/workflows/gate-shadow.yml
@@ -1,0 +1,23 @@
+# Shadow Calibration v2 —— 与 gate.yml 由同一个 pull_request 事件触发的独立 workflow。
+# 影子 reviewer 全部在这里并行跑，绝不阻塞 Required Gate 的 `gate / gate` 结果
+# （legacy 是一个 job 里主审跑完再顺序跑完所有影子才退出，影子墙钟时间直接拖长门禁响应）。
+# 任何影子失败都不改变门禁退出码（不变式 I3）。
+name: gate-shadow
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  gate-shadow:
+    uses: zlxlabs/gate/.github/workflows/gate-shadow-v2.yml@f4c0111a750161a2ed888e7708618580d4bc4e0e
+    with:
+      tier: personal   # 与本仓 gate.yml caller 保持一致
+      runner: self

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -6,8 +6,17 @@
 name: CI
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+    # 纯文档改动跳过门禁——不为 docs/markdown 烧 codex 订阅用量 + 影子 token。
+    # 混合(文档 + 代码)PR 仍会触发门禁(paths-ignore 只在「全部改动都命中」时跳过)。
+    #
+    # PRECONDITION: 任何分支保护规则都不能把本 workflow 的 `gate` job 设为
+    # REQUIRED status check。若未来给本仓加上该必需检查,必须先移除这条
+    # paths-ignore——否则纯文档 PR 永远不会产生该 check run,会永久卡在一个
+    # 不可能变绿的必需 context 上。
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 # The reusable gate requests `pull-requests: write` (for the Codex review comment).
 # The caller MUST grant it here — otherwise the run fails at startup with a
 # generic "workflow file issue" (reusable-workflow permission escalation).
@@ -18,7 +27,7 @@ permissions:
 
 jobs:
   gate:
-    uses: zlxlabs/gate/.github/workflows/gate.yml@main
+    uses: zlxlabs/gate/.github/workflows/gate-v2.yml@f4c0111a750161a2ed888e7708618580d4bc4e0e
     with:
       tier: personal        # personal | internal | saas
       runner: self          # self (self-hosted) | hosted (GitHub free minutes — cold repos / pilot)


### PR DESCRIPTION
## 为什么

legacy 门禁是**一个 job 里主审 failover 链跑完、再顺序跑完所有影子才退出**，影子的墙钟时间直接拖长 required check 响应，且影子越多线性放大（当前 3 条影子腿，实测各 1–5 分钟）。

v2 拆成两个由同一 `pull_request` 事件触发的独立 workflow：Required Gate 只等 `quality ∥ primary`，影子在 Shadow Calibration 里并行矩阵跑，完全不挡门禁。

## 改了什么

- `gate.yml`：`uses` 指向 `gate-v2.yml@f4c0111a7501`（已在 org runner group 白名单内）；`with:` 块原样保留（`tier`/`runner`/`has_ui`/`design_doc` 全不丢）
- `gate.yml`：`types` 补 `ready_for_review` / `converted_to_draft` —— **这是 P0**：v2 的 `primary` 把 draft 当「接受跳过」，缺这个事件的话 PR 转正式后门禁永远不会重跑，会一直停在 draft 期的跳过结果上
- `gate.yml`：新增 `paths-ignore`（`**.md` / `docs/**`），纯文档 PR 不再跑门禁，也不为文档改动烧影子 token
- 新增 `gate-shadow.yml`：影子校准独立 workflow

## 兼容性

聚合 job 的 id 与 name 仍是字面 `gate`，required context 不变，branch protection 零迁移。`name:` 未改动。

设计依据：gate-hub `docs/designs/multi-agent-review-gate.md` §12。
