### PR TITLE
chore: bump gate pin to b080132 (pin-integrity fix)

### DIFF
--- a/.github/workflows/gate-shadow.yml
+++ b/.github/workflows/gate-shadow.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   gate-shadow:
-    uses: zlxlabs/gate/.github/workflows/gate-shadow-v2.yml@9a7927410b8caef10d1c0ae5c31b3bb94bb1f5fc
+    uses: zlxlabs/gate/.github/workflows/gate-shadow-v2.yml@b080132ca8b3cfb3bd6d2a63bb25d07835e793f9
     with:
       tier: personal   # 与本仓 gate.yml caller 保持一致
       runner: self

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   gate:
-    uses: zlxlabs/gate/.github/workflows/gate-v2.yml@9a7927410b8caef10d1c0ae5c31b3bb94bb1f5fc
+    uses: zlxlabs/gate/.github/workflows/gate-v2.yml@b080132ca8b3cfb3bd6d2a63bb25d07835e793f9
     with:
       tier: personal        # personal | internal | saas
       runner: self          # self (self-hosted) | hosted (GitHub free minutes — cold repos / pilot)


### PR DESCRIPTION
Bump gate pin to `b080132ca8b3cfb3bd6d2a63bb25d07835e793f9` for pin-integrity fix (zj1123581321/agent-config#6).

Task-Id: gate-hub-20260801-01